### PR TITLE
MAINT: Adapt to R105 `ChatRoomMessageDisplay()` changes

### DIFF
--- a/src/Modules/MChatroom.ts
+++ b/src/Modules/MChatroom.ts
@@ -157,12 +157,22 @@ export class ChatroomModule extends BaseModule {
 
     pathListHandler(): void {
         // 处理将消息添加右键菜单 (回复、复制、悄悄话、删除)
-        patchFunction("ChatRoomMessageDisplay", {
-            "div.innerHTML = displayMessage;": `
-            if (!!window.AddChatRightClickEvent) window.AddChatRightClickEvent(div);
-            div.innerHTML = displayMessage;
-            `
-        });
+        if (GameVersion === "R104") {
+            patchFunction("ChatRoomMessageDisplay", {
+                "div.innerHTML = displayMessage;": `
+                if (!!window.AddChatRightClickEvent) window.AddChatRightClickEvent(div);
+                div.innerHTML = displayMessage;
+                `
+            });
+        } else {
+            // R105
+            hookFunction("ChatRoomMessageDisplay", 0, (args, next) => {
+                // TODO: Remove the `void`-to-`HTMLDivElement` casting once the BC R105 annotations are available
+                const div = next(args) as any as HTMLDivElement;
+                if (!!window.AddChatRightClickEvent) window.AddChatRightClickEvent(div);
+                return div;
+            });
+        }
     }
 
     // -----------右键菜单----------- //


### PR DESCRIPTION
Adapts to R105 `ChatRoomMessageDisplay()` changes introduced in [BondageProjects/Bondage-College#5067](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5067), which:
(1 breaks the relevant patch due to removal of the to-be substituted line
(2 makes patching redundant as the div in question is now returned, enabling use of a (much less intrusive) hook